### PR TITLE
Add a C++ Puppet RAL example project

### DIFF
--- a/01-Getting-Started.md
+++ b/01-Getting-Started.md
@@ -65,6 +65,8 @@ Add some more complete instruction from one of
 
 Work through some exercises from [Exercism C++ Exercises](https://github.com/exercism/xcpp/blob/master/SETUP.md) with the [C++ Primer](http://www.amazon.com/Primer-5th-Stanley-B-Lippman/dp/0321714113) or [The C++ Programming Language](http://www.amazon.com/The-Programming-Language-4th-Edition/dp/0321563840) at hand.
 
+Since the Puppet RAL is pretty familiar to many of us, it makes a useful example. Create a set of C++ classes representing the RAL, with the ability to print out a representation of them. Then create data structures to represent a catalog, including a relationship [DAG](https://en.wikipedia.org/wiki/Directed_acyclic_graph). A basic example is included in [ral-example](ral-example).
+
 ### Language References
 
 - [C++ Language and Library Reference](http://en.cppreference.com/w/)

--- a/ral-example/.gitignore
+++ b/ral-example/.gitignore
@@ -1,0 +1,3 @@
+/build/
+/release/
+/debug/

--- a/ral-example/CMakeLists.txt
+++ b/ral-example/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.4)
+project(cpp-ral-example)
+
+find_package(Boost 1.57.0 COMPONENTS system filesystem REQUIRED)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+
+set(SOURCE_FILES main.cc resource.cc file.cc package.cc service.cc)
+add_executable(cpp-ral-example ${SOURCE_FILES})
+target_link_libraries(cpp-ral-example ${Boost_LIBRARIES})

--- a/ral-example/file.cc
+++ b/ral-example/file.cc
@@ -1,0 +1,28 @@
+//
+// Created by Michael Smith on 12/8/15.
+//
+
+#include "file.hpp"
+
+namespace Puppet {
+    using namespace std;
+
+    File::File(string name, File::State ensure, boost::filesystem::path path, string source)
+            : Resource(move(name), ensure), path_(move(path)), source_(move(source)) {}
+
+    boost::filesystem::path const& File::path() const
+    {
+        return path_;
+    }
+
+    string const& File::source() const
+    {
+        return source_;
+    }
+
+    string File::print() const
+    {
+        return "file { '" + name() + "':\n\tensure => " + print_ensure(ensure()) + ",\n\tpath => '" + path().string() + "',\n\tsource => '" + source() + "'\n}";
+    }
+
+}

--- a/ral-example/file.hpp
+++ b/ral-example/file.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <boost/filesystem.hpp>
+#include "resource.hpp"
+
+namespace Puppet {
+
+    class File : public Resource {
+    public:
+        File(std::string name, State ensure = State::present, boost::filesystem::path path = {}, std::string source = {});
+        ~File() override {}
+
+        boost::filesystem::path const& path() const;
+        std::string const& source() const;
+
+        std::string print() const override;
+    private:
+        boost::filesystem::path path_;
+        std::string source_;
+    };
+
+}

--- a/ral-example/main.cc
+++ b/ral-example/main.cc
@@ -1,0 +1,55 @@
+#include <iostream>
+#include <vector>
+#include <map>
+#include "resource.hpp"
+#include "file.hpp"
+#include "package.hpp"
+#include "service.hpp"
+
+using namespace std;
+
+int main() {
+    using namespace Puppet;
+
+    //----- Using and printing individual resources. -----
+    Resource r("foo", Resource::State::present);
+    cout << r.print() << endl;
+
+    File file_foo("foo");
+    cout << file_foo << endl;
+
+    Package pkg_foo("foo", Resource::State::absent);
+    cout << pkg_foo << endl;
+
+    Service svc_foo("foo");
+    cout << svc_foo << endl;
+
+    Service svc_bar("bar", Resource::State::present, true);
+    cout << svc_bar << endl;
+
+    cout << endl;
+
+    //----- Creating a graph of resources. -----
+    unique_ptr<Resource> file_f2{new File("f2")};
+
+    vector<shared_ptr<Resource>> resources;
+    resources.emplace_back(move(file_f2));
+    resources.emplace_back(make_shared<File>("f1", Resource::State::present, "/tmp/f1", "file:///path/to/f1"));
+    resources.emplace_back(make_shared<Service>("s1", Resource::State::present));
+    resources.emplace_back(make_shared<Package>("p1", Resource::State::absent));
+
+    for (auto &&r : resources) {
+        cout << *r << endl;
+    }
+
+    multimap<shared_ptr<Resource>, shared_ptr<Resource>> graph;
+    graph.insert(make_pair(resources[0], resources[2]));
+    graph.insert(make_pair(resources[0], resources[1]));
+
+    for (auto &&kv : graph) {
+        cout << *kv.first << " ->\n";
+        cout << *kv.second <<  endl;
+    }
+
+    return 0;
+}

--- a/ral-example/package.cc
+++ b/ral-example/package.cc
@@ -1,0 +1,34 @@
+//
+// Created by Michael Smith on 12/8/15.
+//
+
+#include <boost/algorithm/string/join.hpp>
+#include "package.hpp"
+
+namespace Puppet {
+    using namespace std;
+
+    Package::Package(string name, State ensure, Version version, string source)
+            : Resource(name, ensure), version_(move(version)), source_(move(source)) {}
+
+    Package::Version const& Package::version() const
+    {
+        return version_;
+    }
+
+    string const& Package::source() const
+    {
+        return source_;
+    }
+
+    static string print_version(Package::Version const& version)
+    {
+        return to_string(get<0>(version)) + "." + to_string(get<1>(version)) + "." + to_string(get<2>(version));
+    }
+
+    string Package::print() const
+    {
+        return "package { '" + name() + "':\n\tensure => " + print_ensure(ensure()) + ",\n\tversion => '" + print_version(version()) + "',\n\tsource => '" + source() + "'\n}";
+    }
+
+}

--- a/ral-example/package.hpp
+++ b/ral-example/package.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <tuple>
+#include "resource.hpp"
+
+namespace Puppet {
+
+    class Package : public Resource {
+    public:
+        using Version = std::tuple<unsigned int, unsigned int, unsigned int>;
+
+        Package(std::string name, State ensure = State::present, Version version = {}, std::string source = {});
+        ~Package() override {};
+
+        Version const& version() const;
+        std::string const& source() const;
+
+        std::string print() const override;
+    private:
+        Version version_;
+        std::string source_;
+    };
+
+}

--- a/ral-example/resource.cc
+++ b/ral-example/resource.cc
@@ -1,0 +1,35 @@
+//
+// Created by Michael Smith on 12/8/15.
+//
+
+#include "resource.hpp"
+#include <cassert>
+
+namespace Puppet {
+
+    Resource::Resource(std::string name, State ensure) : name_(std::move(name)), ensure_(ensure) { }
+
+    Resource::State Resource::ensure() const
+    {
+        return ensure_;
+    }
+
+    std::string const& Resource::name() const
+    {
+        return name_;
+    }
+
+    std::string Resource::print_ensure(Resource::State state)
+    {
+        switch (state) {
+            case Resource::State::present: return "present";
+            case Resource::State::absent:  return "absent";
+        }
+    }
+
+    std::string Resource::print() const
+    {
+        return "resource { '" + name() + "':\n\tensure => " + print_ensure(ensure()) + "\n}";
+    }
+
+}

--- a/ral-example/resource.hpp
+++ b/ral-example/resource.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <memory>
+
+namespace Puppet {
+
+    class Resource {
+    public:
+        enum class State {
+            present, absent
+        };
+
+        Resource(std::string name, State ensure);
+        virtual ~Resource() {}
+
+        State ensure() const;
+        std::string const& name() const;
+
+        virtual std::string print() const;
+        static std::string print_ensure(State ensure);
+
+        friend std::ostream& operator<< (std::ostream& stream, const Resource& r)
+        {
+            stream << r.print();
+            return stream;
+        }
+
+    private:
+        State ensure_;
+        std::string name_;
+    };
+
+}

--- a/ral-example/service.cc
+++ b/ral-example/service.cc
@@ -1,0 +1,24 @@
+//
+// Created by Michael Smith on 12/8/15.
+//
+
+#include "service.hpp"
+
+namespace Puppet {
+    using namespace std;
+
+    Service::Service(std::string name, State ensure, boost::optional<bool> enable)
+            : Resource(move(name), ensure), enable_(std::move(enable)) {}
+
+    boost::optional<bool> const& Service::enable() const
+    {
+        return enable_;
+    }
+
+    std::string Service::print() const
+    {
+        auto enable_s = enable() ? (string(",\n\tenable => ") + (*enable() ? "true" : "false") + ",") : "";
+        return "package { '" + name() + "':\n\tensure => " + print_ensure(ensure()) + enable_s + "'\n}";
+    }
+
+}

--- a/ral-example/service.hpp
+++ b/ral-example/service.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <boost/optional.hpp>
+#include "resource.hpp"
+
+namespace Puppet {
+
+    class Service : public Resource {
+    public:
+        Service(std::string name, State ensure = State::present, boost::optional<bool> enable = {});
+        ~Service() override {}
+
+        boost::optional<bool> const& enable() const;
+
+        std::string print() const override;
+    private:
+        boost::optional<bool> enable_;
+    };
+
+}


### PR DESCRIPTION
Presents a basic CMake/C++ project built around representing the
file/service/package resources of the Puppet RAL, and combining them
into a catalog. These are useful for practice with C++ classes,
inheritance, data structures, and managed pointers.